### PR TITLE
Jenkins CI/CD Pipeline Setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+build
+dist
+*.egg-info
+.git
+.cache
+.idea
+.tox

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,76 @@
+#!/usr/bin/env groovy
+
+node {
+    stage("Environment Setup") {
+        echo "Grab Code"
+        checkout scm
+
+        echo "Remove Old Run Data"
+        sh "rm -r *test-results.xml || exit 0"
+
+        if (!fileExists("tests/system/config.ini")) {
+            echo "Copy System Tests' Configuration File"
+            withCredentials([file(
+                    credentialsId: "lets-do-dns-system-test-config",
+                    variable: "SYSTEM_TEST_CONFIG")]) {
+                sh "cp $SYSTEM_TEST_CONFIG tests/system/config.ini"
+            }
+        }
+
+        echo "Create Python 2.7 Build Environment"
+        python_build = docker.build("python:2.7.ldd", "-f jenkins/Dockerfile.py27 .")
+    }
+
+    stage("Build Python Artifact") {
+        python_build.inside {
+            echo "Remove Old Artifacts"
+            sh "rm dist/*.whl || exit 0"
+
+            echo "Create New Artifact"
+            sh "python setup.py bdist_wheel"
+        }
+    }
+
+    stage("Run Python Test Suite") {
+        parallel py27: {
+            echo "Create Python 2.7 Environment"
+            python_27 = docker.build("python:2.7.ldd", "-f jenkins/Dockerfile.py27 .")
+
+            python_27.inside {
+                echo "Install Artifact"
+                sh "pip install dist/*.whl"
+
+                echo "Run py.test Test Suite"
+                try {
+                    sh "py.test --pylama --junit-xml py27-test-results.xml --junit-prefix py27"
+                }
+                finally {
+                    junit "py27-test-results.xml"
+                }
+            }
+        }, py36: {
+            echo "Create Python 3.6 Environment"
+            python_36 = docker.build("python:3.6.ldd", "-f jenkins/Dockerfile.py36 .")
+
+            python_36.inside {
+                echo "Install Artifact"
+                sh "pip install dist/*.whl"
+
+                echo "Run py.test Test Suite"
+                xmlFile = "py36-test-results.xml"
+                try {
+                    sh "py.test --pylama --junit-xml py36-test-results.xml --junit-prefix py36"
+                }
+                finally {
+                    junit "py36-test-results.xml"
+                }
+            }
+        }
+    }
+
+    stage("Archive Python Artifact") {
+        archiveArtifacts artifacts: "dist/*.whl",
+                fingerprint: true,
+                onlyIfSuccessful: true
+    }
+}

--- a/jenkins/Dockerfile.py27
+++ b/jenkins/Dockerfile.py27
@@ -1,0 +1,8 @@
+FROM python:2.7
+
+RUN mkdir /environment
+WORKDIR /environment
+COPY dev-requirements.txt test-requirements.txt requirements.txt /environment/
+
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir -r dev-requirements.txt

--- a/jenkins/Dockerfile.py36
+++ b/jenkins/Dockerfile.py36
@@ -1,0 +1,8 @@
+FROM python:3.6
+
+RUN mkdir /environment
+WORKDIR /environment
+COPY dev-requirements.txt test-requirements.txt requirements.txt /environment/
+
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir -r dev-requirements.txt


### PR DESCRIPTION
This adds the ability to setup a pipeline job in Jenkins to perform continuous integration, and in the future, continuous delivery of the lets-do-dns project.